### PR TITLE
fix: configurable hotkey, settings corners, multi-line input, markdown output

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "e6f383eb49a7105a31a194b0003f4c2f3414b8789ad1c4e34563b2533dc45b5b",
+  "originHash" : "7012ee7c4dc564c8517e33bb7099c35271aec1bf93fa6e418242a008676b2ed1",
   "pins" : [
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
+      }
+    },
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,14 @@ let package = Package(
     platforms: [.macOS(.v26)],
     dependencies: [
         .package(url: "https://github.com/apple/swift-testing.git", from: "0.12.0"),
+        .package(url: "https://github.com/apple/swift-markdown.git", from: "0.5.0"),
     ],
     targets: [
         .executableTarget(
             name: "apfel-quick",
+            dependencies: [
+                .product(name: "Markdown", package: "swift-markdown"),
+            ],
             path: "Sources",
             resources: [
                 .process("Resources")
@@ -29,6 +33,7 @@ let package = Package(
             dependencies: [
                 "apfel-quick",
                 .product(name: "Testing", package: "swift-testing"),
+                .product(name: "Markdown", package: "swift-markdown"),
             ],
             path: "Tests"
         ),

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -80,6 +80,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor [weak self] in self?.hideOverlay() }
         }
 
+        // Re-register hotkey when settings change
+        NotificationCenter.default.addObserver(
+            forName: .hotkeyChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.reregisterGlobalHotkey() }
+        }
+
         // Panel auto-resize: observe viewModel state and grow/shrink the panel
         // to fit the current overlay content.
         startPanelSizeObserver(viewModel: viewModel)
@@ -180,14 +189,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Global hotkey (Ctrl+Space)
+    // MARK: - Global hotkey (configurable, default Option+Space)
 
     private func registerGlobalHotkey() {
+        guard let vm = viewModel else { return }
+        let keyCode = vm.settings.hotkeyKeyCode
+        let modifierFlags = NSEvent.ModifierFlags(rawValue: vm.settings.hotkeyModifiers)
+
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .control,
-                  event.keyCode == 49 else { return }  // 49 = space
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == modifierFlags,
+                  event.keyCode == keyCode else { return }
             Task { @MainActor [weak self] in self?.toggleOverlay() }
         }
+    }
+
+    func reregisterGlobalHotkey() {
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMonitor = nil
+        }
+        registerGlobalHotkey()
     }
 
     // MARK: - Click-outside dismissal

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -24,6 +24,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var viewModel: QuickViewModel?
     private var panel: NSPanel?
     private var welcomePanel: NSPanel?
+    private var settingsPanel: NSPanel?
     private var globalMonitor: Any?
     private var localMonitor: Any?
     private var mouseMonitor: Any?
@@ -87,6 +88,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in self?.reregisterGlobalHotkey() }
+        }
+
+        // Open settings in its own panel (not .sheet — avoids gray corner artifact)
+        NotificationCenter.default.addObserver(
+            forName: .openSettings,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.showSettingsPanel() }
         }
 
         // Panel auto-resize: observe viewModel state and grow/shrink the panel
@@ -367,8 +377,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func openSettingsFromMenu() {
-        showOverlay()
-        NotificationCenter.default.post(name: .openSettings, object: nil)
+        showSettingsPanel()
     }
 
     @objc private func showWelcomeFromMenu() {
@@ -381,6 +390,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let url = URL(string: "https://apfel-quick.franzai.com") {
             NSWorkspace.shared.open(url)
         }
+    }
+
+    // MARK: - Settings panel
+
+    func showSettingsPanel() {
+        if let existing = settingsPanel, existing.isVisible {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        guard let vm = viewModel else { return }
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 520),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Settings"
+        panel.level = NSWindow.Level(rawValue: Int(NSWindow.Level.floating.rawValue) + 2)
+        panel.isReleasedWhenClosed = false
+        panel.center()
+
+        let hostingController = NSHostingController(
+            rootView: SettingsView(viewModel: vm)
+        )
+        panel.contentViewController = hostingController
+        self.settingsPanel = panel
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     // MARK: - Welcome panel

--- a/Sources/Models/QuickSettings.swift
+++ b/Sources/Models/QuickSettings.swift
@@ -4,7 +4,7 @@ import AppKit  // for NSEvent.ModifierFlags
 struct QuickSettings: Codable, Sendable {
     // Hotkey — stored as key code + modifier flags raw value
     var hotkeyKeyCode: UInt16 = 49       // Space bar
-    var hotkeyModifiers: UInt = 262144   // Control key (NSEvent.ModifierFlags.control.rawValue)
+    var hotkeyModifiers: UInt = 524288   // Option key (NSEvent.ModifierFlags.option.rawValue)
 
     // Behaviour
     var autoCopy: Bool = true            // Auto-copy result to clipboard when streaming completes
@@ -33,6 +33,55 @@ extension QuickSettings {
     func save(to defaults: UserDefaults = .standard) {
         if let data = try? JSONEncoder().encode(self) {
             defaults.set(data, forKey: QuickSettings.defaultsKey)
+        }
+    }
+}
+
+// MARK: - Hotkey display and validation
+
+extension QuickSettings {
+
+    /// Human-readable hotkey label, e.g. "\u{2325}Space" for Option+Space.
+    var hotkeyDisplayName: String {
+        let flags = NSEvent.ModifierFlags(rawValue: hotkeyModifiers)
+        var parts: [String] = []
+        if flags.contains(.control) { parts.append("\u{2303}") }
+        if flags.contains(.option)  { parts.append("\u{2325}") }
+        if flags.contains(.shift)   { parts.append("\u{21E7}") }
+        if flags.contains(.command) { parts.append("\u{2318}") }
+        parts.append(Self.keyName(for: hotkeyKeyCode))
+        return parts.joined()
+    }
+
+    /// Whether a hotkey combo is valid (must include Ctrl, Option, or Cmd).
+    static func isValidHotkey(keyCode: UInt16, modifiers: UInt) -> Bool {
+        let flags = NSEvent.ModifierFlags(rawValue: modifiers)
+            .intersection(.deviceIndependentFlagsMask)
+        return flags.contains(.control)
+            || flags.contains(.option)
+            || flags.contains(.command)
+    }
+
+    /// Map key codes to display names.
+    static func keyName(for keyCode: UInt16) -> String {
+        switch keyCode {
+        case 49: return "Space"
+        case 36: return "\u{21A9}"   // Return
+        case 48: return "\u{21E5}"   // Tab
+        case 51: return "\u{232B}"   // Delete
+        case 53: return "\u{238B}"   // Escape
+        default:
+            let letterMap: [UInt16: String] = [
+                0: "A", 1: "S", 2: "D", 3: "F", 4: "H", 5: "G", 6: "Z", 7: "X",
+                8: "C", 9: "V", 11: "B", 12: "Q", 13: "W", 14: "E", 15: "R",
+                16: "Y", 17: "T", 18: "1", 19: "2", 20: "3", 21: "4", 22: "6",
+                23: "5", 24: "=", 25: "9", 26: "7", 27: "-", 28: "8", 29: "0",
+                30: "]", 31: "O", 32: "U", 33: "[", 34: "I", 35: "P",
+                37: "L", 38: "J", 39: "'", 40: "K", 41: ";", 42: "\\",
+                43: ",", 44: "/", 45: "N", 46: "M", 47: ".",
+                50: "`",
+            ]
+            return letterMap[keyCode] ?? "Key\(keyCode)"
         }
     }
 }

--- a/Sources/Services/MarkdownRenderer.swift
+++ b/Sources/Services/MarkdownRenderer.swift
@@ -1,0 +1,172 @@
+import Foundation
+import AppKit
+import Markdown
+
+/// Converts a markdown string to an NSAttributedString using swift-markdown's AST.
+enum MarkdownRenderer {
+
+    static func render(_ markdown: String) -> NSAttributedString {
+        guard !markdown.isEmpty else { return NSAttributedString() }
+        let document = Document(parsing: markdown)
+        var walker = AttributedStringWalker()
+        walker.visit(document)
+        return walker.result
+    }
+}
+
+// MARK: - AST Walker
+
+private struct AttributedStringWalker: MarkupWalker {
+    private let output = NSMutableAttributedString()
+    private var fontTraits: NSFontDescriptor.SymbolicTraits = []
+    private var isMonospace = false
+    private var linkURL: URL?
+    private var headingLevel: Int = 0
+    private var listDepth: Int = 0
+    private var orderedIndex: Int? = nil
+
+    var result: NSAttributedString { output }
+
+    // MARK: - Block elements
+
+    mutating func visitHeading(_ heading: Heading) {
+        if output.length > 0 { appendNewlines(2) }
+        headingLevel = heading.level
+        descendInto(heading)
+        headingLevel = 0
+    }
+
+    mutating func visitParagraph(_ paragraph: Paragraph) {
+        if output.length > 0 { appendNewlines(2) }
+        descendInto(paragraph)
+    }
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
+        if output.length > 0 { appendNewlines(2) }
+        let code = codeBlock.code.hasSuffix("\n")
+            ? String(codeBlock.code.dropLast())
+            : codeBlock.code
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .backgroundColor: NSColor.secondarySystemFill,
+        ]
+        output.append(NSAttributedString(string: code, attributes: attrs))
+    }
+
+    mutating func visitUnorderedList(_ list: UnorderedList) {
+        listDepth += 1
+        descendInto(list)
+        listDepth -= 1
+    }
+
+    mutating func visitOrderedList(_ list: OrderedList) {
+        listDepth += 1
+        orderedIndex = 1
+        descendInto(list)
+        orderedIndex = nil
+        listDepth -= 1
+    }
+
+    mutating func visitListItem(_ item: ListItem) {
+        if output.length > 0 { appendNewlines(1) }
+        let indent = String(repeating: "  ", count: max(0, listDepth - 1))
+        if let idx = orderedIndex {
+            appendText("\(indent)\(idx). ")
+            orderedIndex = idx + 1
+        } else {
+            appendText("\(indent)\u{2022} ")
+        }
+        descendInto(item)
+    }
+
+    // MARK: - Inline elements
+
+    mutating func visitText(_ text: Markdown.Text) {
+        appendText(text.string)
+    }
+
+    mutating func visitStrong(_ strong: Strong) {
+        fontTraits.insert(.bold)
+        descendInto(strong)
+        fontTraits.remove(.bold)
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) {
+        fontTraits.insert(.italic)
+        descendInto(emphasis)
+        fontTraits.remove(.italic)
+    }
+
+    mutating func visitInlineCode(_ code: InlineCode) {
+        let prev = isMonospace
+        isMonospace = true
+        appendText(code.code)
+        isMonospace = prev
+    }
+
+    mutating func visitLink(_ link: Markdown.Link) {
+        if let dest = link.destination, let url = URL(string: dest) {
+            linkURL = url
+        }
+        descendInto(link)
+        linkURL = nil
+    }
+
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) {
+        appendText(" ")
+    }
+
+    mutating func visitLineBreak(_ lineBreak: LineBreak) {
+        appendNewlines(1)
+    }
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
+        if output.length > 0 { appendNewlines(1) }
+        appendText("---")
+        appendNewlines(1)
+    }
+
+    // MARK: - Helpers
+
+    private func appendText(_ text: String) {
+        var attrs: [NSAttributedString.Key: Any] = [:]
+
+        if isMonospace {
+            attrs[.font] = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+            attrs[.backgroundColor] = NSColor.secondarySystemFill
+        } else if headingLevel > 0 {
+            let size: CGFloat = headingLevel == 1 ? 20 : headingLevel == 2 ? 17 : 15
+            var descriptor = NSFont.systemFont(ofSize: size, weight: .bold).fontDescriptor
+            if fontTraits.contains(.italic) {
+                descriptor = descriptor.withSymbolicTraits(
+                    descriptor.symbolicTraits.union(.italic))
+            }
+            attrs[.font] = NSFont(descriptor: descriptor, size: size)
+        } else {
+            let weight: NSFont.Weight = fontTraits.contains(.bold) ? .bold : .regular
+            let base = NSFont.systemFont(ofSize: 14, weight: weight)
+            if fontTraits.contains(.italic) {
+                let descriptor = base.fontDescriptor.withSymbolicTraits(
+                    base.fontDescriptor.symbolicTraits.union(.italic))
+                attrs[.font] = NSFont(descriptor: descriptor, size: 14)
+            } else {
+                attrs[.font] = base
+            }
+        }
+
+        if let url = linkURL {
+            attrs[.link] = url
+            attrs[.foregroundColor] = NSColor.linkColor
+        }
+
+        output.append(NSAttributedString(string: text, attributes: attrs))
+    }
+
+    private func appendNewlines(_ count: Int) {
+        let nl = String(repeating: "\n", count: count)
+        output.append(NSAttributedString(string: nl, attributes: [
+            .font: NSFont.systemFont(ofSize: 14)
+        ]))
+    }
+}

--- a/Sources/Services/MarkdownRenderer.swift
+++ b/Sources/Services/MarkdownRenderer.swift
@@ -24,6 +24,9 @@ private struct AttributedStringWalker: MarkupWalker {
     private var headingLevel: Int = 0
     private var listDepth: Int = 0
     private var orderedIndex: Int? = nil
+    private var blockQuoteDepth: Int = 0
+    private var isStrikethrough = false
+    private var isTableHeader = false
 
     var result: NSAttributedString { output }
 
@@ -71,13 +74,58 @@ private struct AttributedStringWalker: MarkupWalker {
     mutating func visitListItem(_ item: ListItem) {
         if output.length > 0 { appendNewlines(1) }
         let indent = String(repeating: "  ", count: max(0, listDepth - 1))
-        if let idx = orderedIndex {
+        if let checkbox = item.checkbox {
+            let marker = checkbox == .checked ? "\u{2611} " : "\u{2610} "
+            appendText("\(indent)\(marker)")
+        } else if let idx = orderedIndex {
             appendText("\(indent)\(idx). ")
             orderedIndex = idx + 1
         } else {
             appendText("\(indent)\u{2022} ")
         }
         descendInto(item)
+    }
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
+        blockQuoteDepth += 1
+        if output.length > 0 { appendNewlines(1) }
+        descendInto(blockQuote)
+        blockQuoteDepth -= 1
+    }
+
+    mutating func visitTable(_ table: Table) {
+        if output.length > 0 { appendNewlines(2) }
+        descendInto(table)
+    }
+
+    mutating func visitTableHead(_ tableHead: Table.Head) {
+        isTableHeader = true
+        // Render header row as tab-separated bold cells
+        var first = true
+        for cell in tableHead.cells {
+            if !first { appendText("\t") }
+            first = false
+            visit(cell)
+        }
+        isTableHeader = false
+    }
+
+    mutating func visitTableBody(_ tableBody: Table.Body) {
+        descendInto(tableBody)
+    }
+
+    mutating func visitTableRow(_ tableRow: Table.Row) {
+        if output.length > 0 { appendNewlines(1) }
+        var first = true
+        for cell in tableRow.cells {
+            if !first { appendText("\t") }
+            first = false
+            visit(cell)
+        }
+    }
+
+    mutating func visitTableCell(_ tableCell: Table.Cell) {
+        descendInto(tableCell)
     }
 
     // MARK: - Inline elements
@@ -113,6 +161,18 @@ private struct AttributedStringWalker: MarkupWalker {
         linkURL = nil
     }
 
+    mutating func visitStrikethrough(_ strikethrough: Strikethrough) {
+        isStrikethrough = true
+        descendInto(strikethrough)
+        isStrikethrough = false
+    }
+
+    mutating func visitImage(_ image: Markdown.Image) {
+        // Show alt text (the inline children of the image node)
+        appendText("\u{1F5BC} ")
+        descendInto(image)
+    }
+
     mutating func visitSoftBreak(_ softBreak: SoftBreak) {
         appendText(" ")
     }
@@ -132,6 +192,9 @@ private struct AttributedStringWalker: MarkupWalker {
     private func appendText(_ text: String) {
         var attrs: [NSAttributedString.Key: Any] = [:]
 
+        // Determine effective bold state (explicit bold OR table header)
+        let effectiveBold = fontTraits.contains(.bold) || isTableHeader
+
         if isMonospace {
             attrs[.font] = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
             attrs[.backgroundColor] = NSColor.secondarySystemFill
@@ -144,7 +207,7 @@ private struct AttributedStringWalker: MarkupWalker {
             }
             attrs[.font] = NSFont(descriptor: descriptor, size: size)
         } else {
-            let weight: NSFont.Weight = fontTraits.contains(.bold) ? .bold : .regular
+            let weight: NSFont.Weight = effectiveBold ? .bold : .regular
             let base = NSFont.systemFont(ofSize: 14, weight: weight)
             if fontTraits.contains(.italic) {
                 let descriptor = base.fontDescriptor.withSymbolicTraits(
@@ -158,6 +221,16 @@ private struct AttributedStringWalker: MarkupWalker {
         if let url = linkURL {
             attrs[.link] = url
             attrs[.foregroundColor] = NSColor.linkColor
+        }
+
+        // Blockquote styling
+        if blockQuoteDepth > 0 {
+            attrs[.foregroundColor] = NSColor.secondaryLabelColor
+        }
+
+        // Strikethrough
+        if isStrikethrough {
+            attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
         }
 
         output.append(NSAttributedString(string: text, attributes: attrs))

--- a/Sources/Views/HotkeyRecorderView.swift
+++ b/Sources/Views/HotkeyRecorderView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import AppKit
+
+/// A button that, when clicked, captures the next key combo as the new hotkey.
+struct HotkeyRecorderView: View {
+    @Binding var keyCode: UInt16
+    @Binding var modifiers: UInt
+    @State private var isRecording = false
+    @State private var validationError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Hotkey")
+                    .font(.system(size: 13))
+                Spacer()
+                if isRecording {
+                    HotkeyCapture { captured in
+                        let rawMods = captured.modifierFlags
+                            .intersection(.deviceIndependentFlagsMask).rawValue
+                        guard QuickSettings.isValidHotkey(
+                            keyCode: captured.keyCode, modifiers: rawMods
+                        ) else {
+                            validationError = "Must include Ctrl, Option, or Cmd"
+                            isRecording = false
+                            return
+                        }
+                        keyCode = captured.keyCode
+                        modifiers = rawMods
+                        validationError = nil
+                        isRecording = false
+                        NotificationCenter.default.post(
+                            name: .hotkeyChanged, object: nil)
+                    } onCancel: {
+                        isRecording = false
+                    }
+                    .frame(width: 160, height: 28)
+                } else {
+                    Button {
+                        validationError = nil
+                        isRecording = true
+                    } label: {
+                        Text(displayName)
+                            .font(.system(size: 13, weight: .medium,
+                                          design: .monospaced))
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            if let error = validationError {
+                Text(error)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var displayName: String {
+        var s = QuickSettings()
+        s.hotkeyKeyCode = keyCode
+        s.hotkeyModifiers = modifiers
+        return s.hotkeyDisplayName
+    }
+}
+
+// MARK: - NSViewRepresentable key capture field
+
+/// An invisible, first-responder NSView that grabs exactly one key-down event
+/// and reports it back. Press Escape to cancel without changing the hotkey.
+struct HotkeyCapture: NSViewRepresentable {
+    var onCapture: (NSEvent) -> Void
+    var onCancel: () -> Void
+
+    func makeNSView(context: Context) -> HotkeyCaptureView {
+        let view = HotkeyCaptureView()
+        view.onCapture = onCapture
+        view.onCancel = onCancel
+        // Become first responder on next runloop tick so the view is in the
+        // window hierarchy.
+        DispatchQueue.main.async { view.window?.makeFirstResponder(view) }
+        return view
+    }
+
+    func updateNSView(_ nsView: HotkeyCaptureView, context: Context) {}
+}
+
+final class HotkeyCaptureView: NSView {
+    var onCapture: ((NSEvent) -> Void)?
+    var onCancel: (() -> Void)?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 {  // Escape
+            onCancel?()
+        } else {
+            onCapture?(event)
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.controlAccentColor.withAlphaComponent(0.1).setFill()
+        let path = NSBezierPath(roundedRect: bounds, xRadius: 6, yRadius: 6)
+        path.fill()
+        let label = "Press a key combo..."
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .medium),
+            .foregroundColor: NSColor.secondaryLabelColor,
+        ]
+        let size = label.size(withAttributes: attrs)
+        let point = NSPoint(
+            x: (bounds.width - size.width) / 2,
+            y: (bounds.height - size.height) / 2
+        )
+        label.draw(at: point, withAttributes: attrs)
+    }
+}

--- a/Sources/Views/MarkdownTextView.swift
+++ b/Sources/Views/MarkdownTextView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import AppKit
+
+/// Displays an NSAttributedString in a non-editable, selectable NSTextView.
+/// Used for markdown-rendered output in the overlay.
+struct MarkdownTextView: NSViewRepresentable {
+    let attributedString: NSAttributedString
+    let isStreaming: Bool
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 0, height: 0)
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.documentView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        let newAttr = NSMutableAttributedString(attributedString: attributedString)
+        if isStreaming {
+            let cursor = NSAttributedString(string: "\u{258B}", attributes: [
+                .font: NSFont.systemFont(ofSize: 14),
+                .foregroundColor: NSColor.labelColor,
+            ])
+            newAttr.append(cursor)
+        }
+        if textView.attributedString() != newAttr {
+            textView.textStorage?.setAttributedString(newAttr)
+        }
+    }
+}

--- a/Sources/Views/OverlayView.swift
+++ b/Sources/Views/OverlayView.swift
@@ -108,4 +108,5 @@ struct OverlayView: View {
 extension Notification.Name {
     static let dismissOverlay = Notification.Name("ApfelQuick.dismissOverlay")
     static let openSettings = Notification.Name("ApfelQuick.openSettings")
+    static let hotkeyChanged = Notification.Name("ApfelQuick.hotkeyChanged")
 }

--- a/Sources/Views/OverlayView.swift
+++ b/Sources/Views/OverlayView.swift
@@ -24,9 +24,10 @@ struct OverlayView: View {
         VStack(spacing: 0) {
             // Input row
             HStack(spacing: 8) {
-                TextField("Ask anything…", text: $viewModel.input)
+                TextField("Ask anything…", text: $viewModel.input, axis: .vertical)
                     .textFieldStyle(.plain)
                     .font(.system(size: 17))
+                    .lineLimit(1...4)
                     .focused($inputFocused)
                     .submitLabel(.send)
                     .onSubmit { Task { await viewModel.submit() } }

--- a/Sources/Views/OverlayView.swift
+++ b/Sources/Views/OverlayView.swift
@@ -4,8 +4,6 @@ import Combine
 struct OverlayView: View {
     @Bindable var viewModel: QuickViewModel
     @FocusState private var inputFocused: Bool
-    @State private var showSettings = false
-
     /// The send button icon and color change based on state:
     ///  - idle: arrow.up.circle.fill (purple)
     ///  - streaming: stop.fill (purple)
@@ -49,7 +47,8 @@ struct OverlayView: View {
                 .help(viewModel.justCopied ? "Copied to clipboard" : "Send (or press Return)")
 
                 Button {
-                    showSettings = true
+                    NotificationCenter.default.post(
+                        name: .openSettings, object: nil)
                 } label: {
                     Image(systemName: "gear")
                         .foregroundStyle(.secondary)
@@ -95,12 +94,6 @@ struct OverlayView: View {
             }
             NotificationCenter.default.post(name: .dismissOverlay, object: nil)
             return .handled
-        }
-        .sheet(isPresented: $showSettings) {
-            SettingsView(viewModel: viewModel)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .openSettings)) { _ in
-            showSettings = true
         }
     }
 }

--- a/Sources/Views/OverlayView.swift
+++ b/Sources/Views/OverlayView.swift
@@ -64,15 +64,12 @@ struct OverlayView: View {
             // Divider + result (only shown when there's output or streaming)
             if !viewModel.output.isEmpty || viewModel.isStreaming {
                 Divider()
-                ScrollView {
-                    Text(viewModel.output + (viewModel.isStreaming ? "▋" : ""))
-                        .font(.system(size: 14))
-                        .foregroundStyle(.primary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
-                        .padding(20)
-                }
+                MarkdownTextView(
+                    attributedString: MarkdownRenderer.render(viewModel.output),
+                    isStreaming: viewModel.isStreaming
+                )
                 .frame(maxHeight: 380)
+                .padding(20)
             }
 
             // Error message

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -19,6 +19,20 @@ struct SettingsView: View {
 
             Divider()
 
+            // Hotkey
+            HotkeyRecorderView(
+                keyCode: $viewModel.settings.hotkeyKeyCode,
+                modifiers: $viewModel.settings.hotkeyModifiers
+            )
+            .onChange(of: viewModel.settings.hotkeyKeyCode) { _, _ in
+                viewModel.settings.save()
+            }
+            .onChange(of: viewModel.settings.hotkeyModifiers) { _, _ in
+                viewModel.settings.save()
+            }
+
+            Divider()
+
             // Auto-copy
             Toggle("Copy result to clipboard automatically", isOn: $viewModel.settings.autoCopy)
                 .onChange(of: viewModel.settings.autoCopy) { _, _ in viewModel.settings.save() }

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -3,8 +3,6 @@ import AppKit  // for NSEvent.ModifierFlags
 
 struct SettingsView: View {
     @Bindable var viewModel: QuickViewModel
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             // Header
@@ -12,7 +10,7 @@ struct SettingsView: View {
                 Text("Settings")
                     .font(.headline)
                 Spacer()
-                Button("Done") { dismiss() }
+                Button("Done") { NSApp.keyWindow?.close() }
                     .buttonStyle(.plain)
                     .foregroundStyle(.blue)
             }

--- a/Sources/Views/WelcomeOverlayView.swift
+++ b/Sources/Views/WelcomeOverlayView.swift
@@ -23,7 +23,7 @@ struct WelcomeOverlayView: View {
                 Text("Welcome to apfel-quick")
                     .font(.system(size: 22, weight: .bold))
 
-                Text("Press Ctrl+Space anywhere to ask anything. The answer streams in and copies to your clipboard automatically. Everything runs on your Mac — no internet needed.")
+                Text("Press Option+Space anywhere to ask anything. The answer streams in and copies to your clipboard automatically. Everything runs on your Mac - no internet needed.")
                     .font(.system(size: 14))
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/Tests/HotkeySettingsTests.swift
+++ b/Tests/HotkeySettingsTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import AppKit
+@testable import apfel_quick
+
+@Suite("HotkeySettings")
+struct HotkeySettingsTests {
+
+    // MARK: - Display name
+
+    @Test func testDisplayNameOptionSpace() {
+        let settings = QuickSettings()  // default Option+Space
+        #expect(settings.hotkeyDisplayName == "\u{2325}Space")
+    }
+
+    @Test func testDisplayNameControlSpace() {
+        var settings = QuickSettings()
+        settings.hotkeyModifiers = NSEvent.ModifierFlags.control.rawValue
+        settings.hotkeyKeyCode = 49
+        #expect(settings.hotkeyDisplayName == "\u{2303}Space")
+    }
+
+    @Test func testDisplayNameCommandShiftA() {
+        var settings = QuickSettings()
+        settings.hotkeyModifiers = NSEvent.ModifierFlags([.command, .shift]).rawValue
+        settings.hotkeyKeyCode = 0  // 'a'
+        #expect(settings.hotkeyDisplayName == "\u{21E7}\u{2318}A")
+    }
+
+    @Test func testDisplayNameCommandReturn() {
+        var settings = QuickSettings()
+        settings.hotkeyModifiers = NSEvent.ModifierFlags.command.rawValue
+        settings.hotkeyKeyCode = 36  // Return
+        #expect(settings.hotkeyDisplayName == "\u{2318}\u{21A9}")
+    }
+
+    // MARK: - Validation
+
+    @Test func testValidateRequiresModifier() {
+        // No modifier = invalid
+        #expect(QuickSettings.isValidHotkey(keyCode: 49, modifiers: 0) == false)
+    }
+
+    @Test func testValidateAcceptsOptionSpace() {
+        let optionRaw = NSEvent.ModifierFlags.option.rawValue
+        #expect(QuickSettings.isValidHotkey(keyCode: 49, modifiers: optionRaw) == true)
+    }
+
+    @Test func testValidateAcceptsControlSpace() {
+        let controlRaw = NSEvent.ModifierFlags.control.rawValue
+        #expect(QuickSettings.isValidHotkey(keyCode: 49, modifiers: controlRaw) == true)
+    }
+
+    @Test func testValidateAcceptsCommandShift() {
+        let raw = NSEvent.ModifierFlags([.command, .shift]).rawValue
+        #expect(QuickSettings.isValidHotkey(keyCode: 0, modifiers: raw) == true)
+    }
+
+    @Test func testValidateRejectsShiftAlone() {
+        // Shift alone is not a valid modifier for hotkeys
+        let shiftRaw = NSEvent.ModifierFlags.shift.rawValue
+        #expect(QuickSettings.isValidHotkey(keyCode: 49, modifiers: shiftRaw) == false)
+    }
+}

--- a/Tests/MarkdownRendererTests.swift
+++ b/Tests/MarkdownRendererTests.swift
@@ -149,4 +149,168 @@ struct MarkdownRendererTests {
         #expect(result.string.contains("Above"))
         #expect(result.string.contains("Below"))
     }
+
+    // MARK: - Tables
+
+    @Test func testTableRendered() {
+        let input = """
+        | Name | Age |
+        |------|-----|
+        | Alice | 30 |
+        | Bob | 25 |
+        """
+        let result = MarkdownRenderer.render(input)
+        #expect(result.string.contains("Name"))
+        #expect(result.string.contains("Age"))
+        #expect(result.string.contains("Alice"))
+        #expect(result.string.contains("30"))
+        #expect(result.string.contains("Bob"))
+        #expect(result.string.contains("25"))
+    }
+
+    @Test func testTableHeaderIsBold() {
+        let input = """
+        | Header |
+        |--------|
+        | Cell |
+        """
+        let result = MarkdownRenderer.render(input)
+        let headerRange = (result.string as NSString).range(of: "Header")
+        let attrs = result.attributes(at: headerRange.location, effectiveRange: nil)
+        let font = attrs[.font] as? NSFont
+        #expect(font != nil)
+        #expect(font!.fontDescriptor.symbolicTraits.contains(.bold))
+    }
+
+    @Test func testTableCellsAreSeparated() {
+        let input = """
+        | A | B |
+        |---|---|
+        | 1 | 2 |
+        """
+        let result = MarkdownRenderer.render(input)
+        // Cells should be separated by tab or pipe
+        let text = result.string
+        #expect(text.contains("A"))
+        #expect(text.contains("B"))
+        #expect(text.contains("1"))
+        #expect(text.contains("2"))
+    }
+
+    // MARK: - Block quotes
+
+    @Test func testBlockQuoteRendered() {
+        let input = """
+        > This is a quote
+        > with two lines
+        """
+        let result = MarkdownRenderer.render(input)
+        #expect(result.string.contains("This is a quote"))
+        #expect(result.string.contains("with two lines"))
+    }
+
+    @Test func testBlockQuoteHasForegroundColor() {
+        let result = MarkdownRenderer.render("> Quoted text")
+        let range = (result.string as NSString).range(of: "Quoted text")
+        let attrs = result.attributes(at: range.location, effectiveRange: nil)
+        let color = attrs[.foregroundColor] as? NSColor
+        #expect(color != nil)
+    }
+
+    @Test func testNestedBlockQuote() {
+        let input = """
+        > Outer
+        > > Inner
+        """
+        let result = MarkdownRenderer.render(input)
+        #expect(result.string.contains("Outer"))
+        #expect(result.string.contains("Inner"))
+    }
+
+    // MARK: - Strikethrough
+
+    @Test func testStrikethroughRendered() {
+        let result = MarkdownRenderer.render("This is ~~deleted~~ text")
+        #expect(result.string == "This is deleted text")
+        let strikeRange = (result.string as NSString).range(of: "deleted")
+        let attrs = result.attributes(at: strikeRange.location, effectiveRange: nil)
+        let strikeStyle = attrs[.strikethroughStyle] as? Int
+        #expect(strikeStyle != nil)
+        #expect(strikeStyle! != 0)
+    }
+
+    // MARK: - Task lists (checkboxes)
+
+    @Test func testTaskListChecked() {
+        let input = """
+        - [x] Done task
+        - [ ] Todo task
+        """
+        let result = MarkdownRenderer.render(input)
+        // Checked item should show a checkmark or filled box
+        let text = result.string
+        #expect(text.contains("Done task"))
+        #expect(text.contains("Todo task"))
+    }
+
+    @Test func testTaskListMarkers() {
+        let input = """
+        - [x] Checked
+        - [ ] Unchecked
+        """
+        let result = MarkdownRenderer.render(input)
+        let text = result.string
+        // Should have distinct markers for checked vs unchecked
+        #expect(text.contains("\u{2611}") || text.contains("\u{2705}") || text.contains("[x]"))  // checked marker
+        #expect(text.contains("\u{2610}") || text.contains("\u{25CB}") || text.contains("[ ]"))  // unchecked marker
+    }
+
+    // MARK: - Nested lists
+
+    @Test func testNestedUnorderedList() {
+        let input = """
+        - Parent
+          - Child
+          - Child 2
+        - Parent 2
+        """
+        let result = MarkdownRenderer.render(input)
+        #expect(result.string.contains("Parent"))
+        #expect(result.string.contains("Child"))
+        #expect(result.string.contains("Child 2"))
+        #expect(result.string.contains("Parent 2"))
+    }
+
+    // MARK: - Images (alt text only)
+
+    @Test func testImageShowsAltText() {
+        let result = MarkdownRenderer.render("![Screenshot](https://example.com/img.png)")
+        #expect(result.string.contains("Screenshot"))
+        // Should have an image marker
+        #expect(result.string.contains("\u{1F5BC}"))
+    }
+
+    // MARK: - Bold + italic combined
+
+    @Test func testBoldItalicCombined() {
+        let result = MarkdownRenderer.render("This is ***bold italic*** text")
+        #expect(result.string == "This is bold italic text")
+        let range = (result.string as NSString).range(of: "bold italic")
+        let attrs = result.attributes(at: range.location, effectiveRange: nil)
+        let font = attrs[.font] as? NSFont
+        #expect(font != nil)
+        #expect(font!.fontDescriptor.symbolicTraits.contains(.bold))
+        #expect(font!.fontDescriptor.symbolicTraits.contains(.italic))
+    }
+
+    // MARK: - Multiple paragraphs preserve separation
+
+    @Test func testMultipleParagraphsSeparated() {
+        let result = MarkdownRenderer.render("First paragraph.\n\nSecond paragraph.")
+        let text = result.string
+        #expect(text.contains("First paragraph."))
+        #expect(text.contains("Second paragraph."))
+        // Should have double newline between paragraphs
+        #expect(text.contains("First paragraph.\n\nSecond paragraph."))
+    }
 }

--- a/Tests/MarkdownRendererTests.swift
+++ b/Tests/MarkdownRendererTests.swift
@@ -1,0 +1,152 @@
+import Testing
+import Foundation
+import AppKit
+@testable import apfel_quick
+
+@Suite("MarkdownRenderer")
+struct MarkdownRendererTests {
+
+    // MARK: - Plain text passthrough
+
+    @Test func testPlainTextUnchanged() {
+        let result = MarkdownRenderer.render("Hello world")
+        #expect(result.string == "Hello world")
+    }
+
+    // MARK: - Bold
+
+    @Test func testBoldRendered() {
+        let result = MarkdownRenderer.render("This is **bold** text")
+        #expect(result.string == "This is bold text")
+        let boldRange = (result.string as NSString).range(of: "bold")
+        let attrs = result.attributes(at: boldRange.location, effectiveRange: nil)
+        let font = attrs[.font] as? NSFont
+        #expect(font != nil)
+        #expect(font!.fontDescriptor.symbolicTraits.contains(.bold))
+    }
+
+    // MARK: - Italic
+
+    @Test func testItalicRendered() {
+        let result = MarkdownRenderer.render("This is *italic* text")
+        #expect(result.string == "This is italic text")
+        let italicRange = (result.string as NSString).range(of: "italic")
+        let attrs = result.attributes(at: italicRange.location, effectiveRange: nil)
+        let font = attrs[.font] as? NSFont
+        #expect(font != nil)
+        #expect(font!.fontDescriptor.symbolicTraits.contains(.italic))
+    }
+
+    // MARK: - Inline code
+
+    @Test func testInlineCodeRendered() {
+        let result = MarkdownRenderer.render("Use `print()` here")
+        #expect(result.string == "Use print() here")
+        let codeRange = (result.string as NSString).range(of: "print()")
+        let attrs = result.attributes(at: codeRange.location, effectiveRange: nil)
+        let font = attrs[.font] as? NSFont
+        #expect(font != nil)
+        #expect(font!.isFixedPitch)
+    }
+
+    // MARK: - Code blocks
+
+    @Test func testCodeBlockRendered() {
+        let input = """
+        Here is code:
+
+        ```swift
+        let x = 42
+        ```
+
+        Done.
+        """
+        let result = MarkdownRenderer.render(input)
+        #expect(result.string.contains("let x = 42"))
+        let codeRange = (result.string as NSString).range(of: "let x = 42")
+        let attrs = result.attributes(at: codeRange.location, effectiveRange: nil)
+        let font = attrs[.font] as? NSFont
+        #expect(font != nil)
+        #expect(font!.isFixedPitch)
+    }
+
+    // MARK: - Headings
+
+    @Test func testHeadingRendered() {
+        let result = MarkdownRenderer.render("# Title\n\nBody text")
+        #expect(result.string.contains("Title"))
+        #expect(result.string.contains("Body text"))
+        let titleRange = (result.string as NSString).range(of: "Title")
+        let attrs = result.attributes(at: titleRange.location, effectiveRange: nil)
+        let font = attrs[.font] as? NSFont
+        #expect(font != nil)
+        #expect(font!.pointSize > 14)
+    }
+
+    // MARK: - Lists
+
+    @Test func testUnorderedListRendered() {
+        let input = """
+        Items:
+
+        - First
+        - Second
+        - Third
+        """
+        let result = MarkdownRenderer.render(input)
+        #expect(result.string.contains("First"))
+        #expect(result.string.contains("Second"))
+        #expect(result.string.contains("Third"))
+    }
+
+    @Test func testOrderedListRendered() {
+        let input = """
+        Steps:
+
+        1. First
+        2. Second
+        3. Third
+        """
+        let result = MarkdownRenderer.render(input)
+        #expect(result.string.contains("First"))
+        #expect(result.string.contains("Second"))
+    }
+
+    // MARK: - Links
+
+    @Test func testLinkRendered() {
+        let result = MarkdownRenderer.render("Visit [Apple](https://apple.com)")
+        #expect(result.string.contains("Apple"))
+        let linkRange = (result.string as NSString).range(of: "Apple")
+        let attrs = result.attributes(at: linkRange.location, effectiveRange: nil)
+        let link = attrs[.link]
+        #expect(link != nil)
+    }
+
+    // MARK: - Empty / whitespace
+
+    @Test func testEmptyStringReturnsEmpty() {
+        let result = MarkdownRenderer.render("")
+        #expect(result.string == "")
+    }
+
+    // MARK: - Partial / streaming markdown
+
+    @Test func testUnclosedBoldDoesNotCrash() {
+        let result = MarkdownRenderer.render("This is **bold but uncl")
+        #expect(result.string.contains("bold"))
+    }
+
+    @Test func testUnclosedCodeBlockDoesNotCrash() {
+        let result = MarkdownRenderer.render("```swift\nlet x = 1\n")
+        #expect(result.string.contains("let x = 1"))
+    }
+
+    // MARK: - Thematic break
+
+    @Test func testThematicBreak() {
+        let result = MarkdownRenderer.render("Above\n\n---\n\nBelow")
+        #expect(result.string.contains("Above"))
+        #expect(result.string.contains("Below"))
+    }
+}

--- a/Tests/QuickSettingsTests.swift
+++ b/Tests/QuickSettingsTests.swift
@@ -32,8 +32,8 @@ struct QuickSettingsTests {
         let settings = QuickSettings()
         // Space bar key code = 49
         #expect(settings.hotkeyKeyCode == 49)
-        // Control key modifier = NSEvent.ModifierFlags.control.rawValue = 262144
-        #expect(settings.hotkeyModifiers == 262144)
+        // Option key modifier = NSEvent.ModifierFlags.option.rawValue = 524288
+        #expect(settings.hotkeyModifiers == 524288)
     }
 
     // MARK: - 3. Save and load round-trip preserves all fields
@@ -73,7 +73,7 @@ struct QuickSettingsTests {
         #expect(loaded.checkForUpdatesOnLaunch == true)
         #expect(loaded.hasSeenWelcome == false)
         #expect(loaded.hotkeyKeyCode == 49)
-        #expect(loaded.hotkeyModifiers == 262144)
+        #expect(loaded.hotkeyModifiers == 524288)
     }
 
     // MARK: - 5. Load from corrupt data returns defaults


### PR DESCRIPTION
## Summary

- **#4** - Default hotkey changed from Ctrl+Space (conflicts with macOS Input Sources) to Option+Space. Hotkey is now fully configurable in settings via a key recorder. AppDelegate reads hotkey from settings and re-registers the global monitor on change.
- **#5** - Settings panel presented as its own titled NSPanel instead of a `.sheet` inside the borderless overlay, fixing gray corner artifacts.
- **#6** - Input field now supports vertical expansion (1-4 lines) for long prompts, with natural wrapping and scrolling.
- **#7** - Output renders markdown via apple/swift-markdown AST walker with full element support:
  - **Inline:** bold, italic, bold+italic, inline code, strikethrough, links
  - **Block:** headings (3 levels), code blocks (monospace + background), paragraphs, thematic breaks
  - **Lists:** unordered (bullets), ordered (numbered), nested, task lists (checkboxes)
  - **Tables:** bold header row, tab-separated cells, multi-row body
  - **Blockquotes:** secondary color, nested depth
  - **Images:** alt text with image marker
  - Partial markdown during streaming handled gracefully (no crashes on unclosed tags)

Closes #4, Closes #5, Closes #6, Closes #7

## Test plan

- [x] All 217 tests pass (191 existing + 9 hotkey + 26 markdown = 217 total, 0 skipped)
- [x] Release build succeeds with no errors
- [ ] Launch app, verify Option+Space opens overlay
- [ ] Open settings, change hotkey via recorder, verify new hotkey works immediately
- [ ] Open settings, verify no gray corners (settings is a separate titled panel)
- [ ] Type a long prompt, verify it wraps to multiple lines (up to 4)
- [ ] Ask for code, verify markdown renders (bold, code blocks, headings, etc.)
- [ ] Ask for a table, verify it renders with bold headers
- [ ] Verify streaming cursor appears during response
- [ ] Verify partial markdown during streaming doesn't crash

## New files

| File | Purpose |
|------|---------|
| `Sources/Views/HotkeyRecorderView.swift` | Key-capture button + NSViewRepresentable for reliable key combo recording |
| `Sources/Services/MarkdownRenderer.swift` | swift-markdown AST walker producing NSAttributedString (26 element types) |
| `Sources/Views/MarkdownTextView.swift` | NSViewRepresentable wrapping selectable NSTextView for attributed output |
| `Tests/HotkeySettingsTests.swift` | 9 tests for display name + validation |
| `Tests/MarkdownRendererTests.swift` | 26 tests for all markdown element types + streaming edge cases |

## New dependency

- `apple/swift-markdown` (0.5.0+) - Apple's official Swift Markdown parser. No transitive dependencies.