### PR TITLE
feat(#10): user-selectable light / dark / system appearance

### DIFF
--- a/Sources/Models/AppearancePreference.swift
+++ b/Sources/Models/AppearancePreference.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftUI
+
+/// User-selectable appearance for the overlay and settings window.
+enum AppearancePreference: String, Codable, Sendable, CaseIterable {
+    case system
+    case light
+    case dark
+
+    /// `nil` means "follow the system appearance"; SwiftUI interprets a nil
+    /// `preferredColorScheme` as "do not override".
+    var swiftUIColorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .system: return "Follow system"
+        case .light: return "Light"
+        case .dark: return "Dark"
+        }
+    }
+}

--- a/Sources/Models/QuickSettings.swift
+++ b/Sources/Models/QuickSettings.swift
@@ -22,6 +22,9 @@ struct QuickSettings: Codable, Sendable {
     var savedPromptPrefix: String = "/"
     var savedPrompts: [SavedPrompt] = SavedPrompt.defaults
 
+    // Appearance
+    var appearance: AppearancePreference = .system
+
     // Persistence key
     static let defaultsKey = "QuickSettings"
 
@@ -39,6 +42,7 @@ struct QuickSettings: Codable, Sendable {
         launchAtLoginPromptShown = try c.decodeIfPresent(Bool.self, forKey: .launchAtLoginPromptShown) ?? false
         savedPromptPrefix = try c.decodeIfPresent(String.self, forKey: .savedPromptPrefix) ?? "/"
         savedPrompts = try c.decodeIfPresent([SavedPrompt].self, forKey: .savedPrompts) ?? SavedPrompt.defaults
+        appearance = try c.decodeIfPresent(AppearancePreference.self, forKey: .appearance) ?? .system
     }
 
     init() {}

--- a/Sources/Views/OverlayView.swift
+++ b/Sources/Views/OverlayView.swift
@@ -109,9 +109,9 @@ struct OverlayView: View {
                     .padding(.vertical, 8)
             }
         }
-        .background(.white)
+        .background(Color(NSColor.windowBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 16))
-        .preferredColorScheme(.light)
+        .preferredColorScheme(viewModel.settings.appearance.swiftUIColorScheme)
         .onAppear { inputFocused = true }
         .onKeyPress(.escape) {
             if viewModel.isStreaming {

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -54,6 +54,21 @@ struct SettingsView: View {
             Toggle("Check for updates on launch", isOn: $viewModel.settings.checkForUpdatesOnLaunch)
                 .onChange(of: viewModel.settings.checkForUpdatesOnLaunch) { _, _ in viewModel.settings.save() }
 
+            // Appearance
+            HStack {
+                Text("Appearance")
+                Spacer()
+                Picker("", selection: $viewModel.settings.appearance) {
+                    ForEach(AppearancePreference.allCases, id: \.self) { pref in
+                        Text(pref.displayName).tag(pref)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 280)
+                .onChange(of: viewModel.settings.appearance) { _, _ in viewModel.settings.save() }
+            }
+
             // Show welcome screen on next launch
             Toggle("Show welcome screen on next launch", isOn: Binding(
                 get: { !viewModel.settings.hasSeenWelcome },
@@ -92,9 +107,9 @@ struct SettingsView: View {
             }
         }
         .padding(28)
-        .frame(width: 560, height: 780)
-        .background(.white)
-        .preferredColorScheme(.light)
+        .frame(width: 560, height: 820)
+        .background(Color(NSColor.windowBackgroundColor))
+        .preferredColorScheme(viewModel.settings.appearance.swiftUIColorScheme)
     }
 
     @ViewBuilder

--- a/Tests/AppearanceTests.swift
+++ b/Tests/AppearanceTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+import SwiftUI
+@testable import apfel_quick
+
+/// TDD (RED) for dark mode (issue #10).
+///
+/// Spec:
+/// - QuickSettings.colorScheme: `.system | .light | .dark`, default `.system`.
+/// - AppearancePreference maps each case to `SwiftUI.ColorScheme?`
+///   (nil = "follow system").
+/// - Legacy QuickSettings blobs written before this feature still decode.
+
+@Suite("AppearancePreference")
+struct AppearancePreferenceTests {
+
+    @Test func testCasesExist() {
+        _ = AppearancePreference.system
+        _ = AppearancePreference.light
+        _ = AppearancePreference.dark
+    }
+
+    @Test func testSystemMapsToNilColorScheme() {
+        #expect(AppearancePreference.system.swiftUIColorScheme == nil)
+    }
+
+    @Test func testLightMapsToLight() {
+        #expect(AppearancePreference.light.swiftUIColorScheme == .light)
+    }
+
+    @Test func testDarkMapsToDark() {
+        #expect(AppearancePreference.dark.swiftUIColorScheme == .dark)
+    }
+
+    @Test func testCodableRoundTrip() throws {
+        for c in AppearancePreference.allCases {
+            let data = try JSONEncoder().encode(c)
+            let back = try JSONDecoder().decode(AppearancePreference.self, from: data)
+            #expect(back == c)
+        }
+    }
+
+    @Test func testDisplayNameIsHumanReadable() {
+        for c in AppearancePreference.allCases {
+            #expect(!c.displayName.isEmpty)
+        }
+        #expect(AppearancePreference.system.displayName == "Follow system")
+        #expect(AppearancePreference.light.displayName == "Light")
+        #expect(AppearancePreference.dark.displayName == "Dark")
+    }
+
+    @Test func testAllCasesCount() {
+        #expect(AppearancePreference.allCases.count == 3)
+    }
+}
+
+@Suite("QuickSettings appearance")
+struct QuickSettingsAppearanceTests {
+
+    @Test func testDefaultIsSystem() {
+        let s = QuickSettings()
+        #expect(s.appearance == .system)
+    }
+
+    @Test func testCustomAppearanceRoundTrips() throws {
+        var s = QuickSettings()
+        s.appearance = .dark
+        let data = try JSONEncoder().encode(s)
+        let back = try JSONDecoder().decode(QuickSettings.self, from: data)
+        #expect(back.appearance == .dark)
+    }
+
+    @Test func testLegacyBlobWithoutAppearanceDecodes() throws {
+        let legacy = #"""
+        {"hotkeyKeyCode":49,"hotkeyModifiers":524288,"autoCopy":true,"launchAtLogin":true,"showMenuBar":true,"checkForUpdatesOnLaunch":true,"hasSeenWelcome":true,"launchAtLoginPromptShown":true}
+        """#
+        let s = try JSONDecoder().decode(QuickSettings.self, from: Data(legacy.utf8))
+        #expect(s.appearance == .system)
+    }
+}

--- a/Tests/LightModeEnforcementTests.swift
+++ b/Tests/LightModeEnforcementTests.swift
@@ -1,11 +1,17 @@
-// LightModeEnforcementTests — regression test for issue #1
+// LightModeEnforcementTests — regression guard for issue #1.
 //
-// User-facing overlays must lock their color scheme to .light. Without this,
-// dark-mode users see `.foregroundStyle(.secondary)` (which resolves to a
-// light colour in dark mode) rendered on top of an explicit `.background(.white)`,
-// producing invisible text on the Welcome, Settings, and Overlay surfaces.
+// User-facing overlays must not mix a hardcoded `.background(.white)` with
+// semantic foreground colors like `.foregroundStyle(.secondary)` while in
+// dark mode, because that produces invisible text.
+//
+// After issue #10 the app supports a user-selectable appearance
+// (system / light / dark). The invariant now is: each overlay view must
+// either pin `.preferredColorScheme(.light)` explicitly, OR route its
+// color scheme through `settings.appearance.swiftUIColorScheme` so the
+// user stays in control AND the background is adaptive.
 //
 // https://github.com/Arthur-Ficial/apfel-quick/issues/1
+// https://github.com/Arthur-Ficial/apfel-quick/issues/10
 
 import Foundation
 import Testing
@@ -19,20 +25,42 @@ struct LightModeEnforcementTests {
         return url.appendingPathComponent("Sources/Views", isDirectory: true)
     }()
 
-    private static let viewsRequiringLightMode = [
+    private static let overlayViews = [
         "WelcomeOverlayView.swift",
         "SettingsView.swift",
         "OverlayView.swift",
     ]
 
-    @Test("Every user-facing view declares .preferredColorScheme(.light)",
-          arguments: viewsRequiringLightMode)
-    func viewLocksLightMode(name: String) throws {
+    @Test("Every overlay view controls its color scheme (hardcoded light or settings-driven)",
+          arguments: overlayViews)
+    func viewControlsColorScheme(name: String) throws {
         let url = Self.viewsDir.appendingPathComponent(name)
         let source = try String(contentsOf: url, encoding: .utf8)
+        let locksLight = source.contains(".preferredColorScheme(.light)")
+        let usesAppearance = source.contains("appearance.swiftUIColorScheme")
         #expect(
-            source.contains(".preferredColorScheme(.light)"),
-            "\(name) must declare .preferredColorScheme(.light) so dark-mode users don't see invisible text on the explicit white background"
+            locksLight || usesAppearance,
+            "\(name) must either pin `.preferredColorScheme(.light)` or route through `settings.appearance.swiftUIColorScheme` so dark-mode users don't see invisible text."
         )
+    }
+
+    @Test("Views that opt into user-driven appearance must use adaptive backgrounds",
+          arguments: overlayViews)
+    func adaptiveBackgroundWhenAppearanceDriven(name: String) throws {
+        let url = Self.viewsDir.appendingPathComponent(name)
+        let source = try String(contentsOf: url, encoding: .utf8)
+        let usesAppearance = source.contains("appearance.swiftUIColorScheme")
+        if usesAppearance {
+            // Explicit white background while allowing dark mode would make
+            // `.foregroundStyle(.secondary)` invisible (the original bug).
+            // Allow `.background(.white)` only paired with a hardcoded
+            // `.preferredColorScheme(.light)`.
+            let hasWhiteBackground = source.contains(".background(.white)")
+                || source.contains(".background(Color.white)")
+            #expect(
+                !hasWhiteBackground,
+                "\(name) routes color scheme through settings but hardcodes `.background(.white)`. Use `Color(NSColor.windowBackgroundColor)` instead."
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #10. Adds an Appearance picker in Settings: **Follow system / Light / Dark**. Backgrounds switch to `Color(NSColor.windowBackgroundColor)` so they adapt automatically; `preferredColorScheme` is routed through settings.

## TDD coverage

- `AppearancePreferenceTests` (6): all three cases, Codable round-trip, correct SwiftUI mapping, display names
- `QuickSettingsAppearanceTests` (3): default `.system`, custom round-trip, legacy-blob tolerance
- `LightModeEnforcementTests` rewritten: the regression guard for [issue #1](https://github.com/Arthur-Ficial/apfel-quick/issues/1) now allows the user-driven path AND forbids the exact combination that caused the original bug (`.background(.white)` + `.preferredColorScheme(nil)`)

## Test plan

- [x] `swift test` green (211 / 15 suites, +11 from baseline)
- [x] `swift build -c release` clean
- [x] Settings has an Appearance segmented picker (3 options)
- [x] Changing Appearance updates overlay + settings live
- [x] Welcome screen retains hardcoded light mode (first-run, before user prefs exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)