### PR TITLE
feat(#9): MCP server enable/disable from Settings

### DIFF
--- a/Sources/App/ServerManager.swift
+++ b/Sources/App/ServerManager.swift
@@ -19,8 +19,10 @@ final class ServerManager {
     private(set) var state: State = .idle
     private let backing: ApfelServer
 
-    init() {
-        self.backing = ApfelServer()
+    init(settings: QuickSettings = .load()) {
+        self.backing = ApfelServer(
+            arguments: ApfelArgumentsBuilder.build(mcpServers: settings.mcpServers)
+        )
     }
 
     // MARK: - Static helpers kept for call-site and test compatibility

--- a/Sources/Models/MCPServerConfig.swift
+++ b/Sources/Models/MCPServerConfig.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// A user-configured MCP (Model Context Protocol) server. When `enabled`
+/// is true, `ApfelArgumentsBuilder` appends `--mcp <path>` to the apfel
+/// server spawn, exposing the server's tools to the on-device model.
+struct MCPServerConfig: Codable, Sendable, Equatable, Identifiable, Hashable {
+    let id: UUID
+    var name: String
+    var path: String
+    var enabled: Bool
+
+    init(id: UUID = UUID(), name: String, path: String, enabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.path = path
+        self.enabled = enabled
+    }
+}

--- a/Sources/Models/QuickSettings.swift
+++ b/Sources/Models/QuickSettings.swift
@@ -25,6 +25,9 @@ struct QuickSettings: Codable, Sendable {
     // Appearance
     var appearance: AppearancePreference = .system
 
+    // MCP servers (attached to apfel --serve at launch)
+    var mcpServers: [MCPServerConfig] = []
+
     // Persistence key
     static let defaultsKey = "QuickSettings"
 
@@ -43,6 +46,7 @@ struct QuickSettings: Codable, Sendable {
         savedPromptPrefix = try c.decodeIfPresent(String.self, forKey: .savedPromptPrefix) ?? "/"
         savedPrompts = try c.decodeIfPresent([SavedPrompt].self, forKey: .savedPrompts) ?? SavedPrompt.defaults
         appearance = try c.decodeIfPresent(AppearancePreference.self, forKey: .appearance) ?? .system
+        mcpServers = try c.decodeIfPresent([MCPServerConfig].self, forKey: .mcpServers) ?? []
     }
 
     init() {}

--- a/Sources/Services/ApfelArgumentsBuilder.swift
+++ b/Sources/Services/ApfelArgumentsBuilder.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Pure builder for the argument list passed to `apfel --serve`. Always
+/// emits `--cors --permissive` (apfel-quick's required defaults) and
+/// appends `--mcp <path>` for each enabled MCP server with a non-empty
+/// path.
+enum ApfelArgumentsBuilder {
+    static func build(mcpServers: [MCPServerConfig]) -> [String] {
+        var args: [String] = ["--cors", "--permissive"]
+        for server in mcpServers where server.enabled && !server.path.isEmpty {
+            args.append("--mcp")
+            args.append(server.path)
+        }
+        return args
+    }
+}

--- a/Sources/Views/MCPServersEditor.swift
+++ b/Sources/Views/MCPServersEditor.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+import AppKit
+
+/// Settings pane for enabling / disabling MCP servers attached to the
+/// embedded apfel process. Changes take effect on the next app launch
+/// (or on the next time the server is restarted) since they are passed
+/// as command-line arguments to `apfel --serve`.
+struct MCPServersEditor: View {
+    @Bindable var viewModel: QuickViewModel
+    @State private var selection: MCPServerConfig.ID?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("MCP Servers")
+                    .font(.headline)
+                Spacer()
+                Text("Applied on next launch")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+
+            if viewModel.settings.mcpServers.isEmpty {
+                Text("No MCP servers configured. Click + to add a local MCP script or binary.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 12)
+            } else {
+                Table(viewModel.settings.mcpServers, selection: $selection) {
+                    TableColumn("On") { config in
+                        Toggle("", isOn: bindingForEnabled(config.id))
+                            .labelsHidden()
+                    }
+                    .width(40)
+                    TableColumn("Name") { config in
+                        TextField("name", text: bindingForName(config.id))
+                            .textFieldStyle(.plain)
+                    }
+                    .width(min: 80, max: 140)
+                    TableColumn("Path") { config in
+                        TextField("/path/to/server.py or script", text: bindingForPath(config.id))
+                            .textFieldStyle(.plain)
+                    }
+                }
+                .frame(minHeight: 140)
+            }
+
+            HStack {
+                Button {
+                    addRow()
+                } label: {
+                    Image(systemName: "plus")
+                }
+                Button {
+                    pickPath()
+                } label: {
+                    Image(systemName: "folder")
+                }
+                .help("Browse for an MCP server file")
+                Button {
+                    removeSelected()
+                } label: {
+                    Image(systemName: "minus")
+                }
+                .disabled(selection == nil)
+                Spacer()
+            }
+        }
+    }
+
+    private func bindingForEnabled(_ id: MCPServerConfig.ID) -> Binding<Bool> {
+        Binding(
+            get: { viewModel.settings.mcpServers.first(where: { $0.id == id })?.enabled ?? false },
+            set: { newValue in
+                if let index = viewModel.settings.mcpServers.firstIndex(where: { $0.id == id }) {
+                    viewModel.settings.mcpServers[index].enabled = newValue
+                    viewModel.settings.save()
+                }
+            }
+        )
+    }
+
+    private func bindingForName(_ id: MCPServerConfig.ID) -> Binding<String> {
+        Binding(
+            get: { viewModel.settings.mcpServers.first(where: { $0.id == id })?.name ?? "" },
+            set: { newValue in
+                if let index = viewModel.settings.mcpServers.firstIndex(where: { $0.id == id }) {
+                    viewModel.settings.mcpServers[index].name = newValue
+                    viewModel.settings.save()
+                }
+            }
+        )
+    }
+
+    private func bindingForPath(_ id: MCPServerConfig.ID) -> Binding<String> {
+        Binding(
+            get: { viewModel.settings.mcpServers.first(where: { $0.id == id })?.path ?? "" },
+            set: { newValue in
+                if let index = viewModel.settings.mcpServers.firstIndex(where: { $0.id == id }) {
+                    viewModel.settings.mcpServers[index].path = newValue
+                    viewModel.settings.save()
+                }
+            }
+        )
+    }
+
+    private func addRow() {
+        let new = MCPServerConfig(name: "new-server", path: "", enabled: true)
+        viewModel.settings.mcpServers.append(new)
+        viewModel.settings.save()
+        selection = new.id
+    }
+
+    private func pickPath() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            let name = url.deletingPathExtension().lastPathComponent
+            let new = MCPServerConfig(name: name, path: url.path, enabled: true)
+            viewModel.settings.mcpServers.append(new)
+            viewModel.settings.save()
+            selection = new.id
+        }
+    }
+
+    private func removeSelected() {
+        guard let selection else { return }
+        viewModel.settings.mcpServers.removeAll { $0.id == selection }
+        viewModel.settings.save()
+        self.selection = nil
+    }
+}

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -69,6 +69,10 @@ struct SettingsView: View {
                 .onChange(of: viewModel.settings.appearance) { _, _ in viewModel.settings.save() }
             }
 
+            Divider()
+
+            MCPServersEditor(viewModel: viewModel)
+
             // Show welcome screen on next launch
             Toggle("Show welcome screen on next launch", isOn: Binding(
                 get: { !viewModel.settings.hasSeenWelcome },
@@ -107,7 +111,7 @@ struct SettingsView: View {
             }
         }
         .padding(28)
-        .frame(width: 560, height: 820)
+        .frame(width: 560, height: 960)
         .background(Color(NSColor.windowBackgroundColor))
         .preferredColorScheme(viewModel.settings.appearance.swiftUIColorScheme)
     }

--- a/Tests/MCPServerConfigTests.swift
+++ b/Tests/MCPServerConfigTests.swift
@@ -1,0 +1,124 @@
+import Testing
+import Foundation
+@testable import apfel_quick
+
+/// TDD (RED) for MCP enable/disable (issue #9).
+///
+/// Spec:
+/// - A configured MCP server has id, name, path, enabled fields.
+/// - QuickSettings stores a list of them.
+/// - ApfelArgumentsBuilder builds the `[String]` passed to `apfel --serve`
+///   by starting with `--cors --permissive` and appending `--mcp <path>`
+///   for each ENABLED server (disabled ones are skipped).
+
+@Suite("MCPServerConfig")
+struct MCPServerConfigTests {
+
+    @Test func testInitDefaultsEnabled() {
+        let c = MCPServerConfig(name: "Calc", path: "/tmp/calc.py")
+        #expect(c.enabled == true)
+    }
+
+    @Test func testCodableRoundTrip() throws {
+        let c = MCPServerConfig(name: "Calc", path: "/tmp/calc.py", enabled: false)
+        let data = try JSONEncoder().encode(c)
+        let back = try JSONDecoder().decode(MCPServerConfig.self, from: data)
+        #expect(back.name == c.name)
+        #expect(back.path == c.path)
+        #expect(back.enabled == c.enabled)
+        #expect(back.id == c.id)
+    }
+
+    @Test func testIdentifiableIsUnique() {
+        let a = MCPServerConfig(name: "A", path: "/a")
+        let b = MCPServerConfig(name: "B", path: "/b")
+        #expect(a.id != b.id)
+    }
+}
+
+@Suite("ApfelArgumentsBuilder")
+struct ApfelArgumentsBuilderTests {
+
+    @Test func testNoServersProducesBaseArgs() {
+        let args = ApfelArgumentsBuilder.build(mcpServers: [])
+        #expect(args == ["--cors", "--permissive"])
+    }
+
+    @Test func testOneEnabledServerAppendsMcpPair() {
+        let args = ApfelArgumentsBuilder.build(mcpServers: [
+            MCPServerConfig(name: "calc", path: "/tmp/calc.py", enabled: true)
+        ])
+        #expect(args == ["--cors", "--permissive", "--mcp", "/tmp/calc.py"])
+    }
+
+    @Test func testDisabledServerIsOmitted() {
+        let args = ApfelArgumentsBuilder.build(mcpServers: [
+            MCPServerConfig(name: "calc", path: "/tmp/calc.py", enabled: false)
+        ])
+        #expect(args == ["--cors", "--permissive"])
+    }
+
+    @Test func testMultipleEnabledServersEachGetTheirOwnPair() {
+        let args = ApfelArgumentsBuilder.build(mcpServers: [
+            MCPServerConfig(name: "calc", path: "/tmp/calc.py", enabled: true),
+            MCPServerConfig(name: "web", path: "/tmp/web.py", enabled: true),
+        ])
+        #expect(args == [
+            "--cors", "--permissive",
+            "--mcp", "/tmp/calc.py",
+            "--mcp", "/tmp/web.py",
+        ])
+    }
+
+    @Test func testMixedEnabledAndDisabledPreservesOrderAndSkipsDisabled() {
+        let args = ApfelArgumentsBuilder.build(mcpServers: [
+            MCPServerConfig(name: "a", path: "/a", enabled: true),
+            MCPServerConfig(name: "b", path: "/b", enabled: false),
+            MCPServerConfig(name: "c", path: "/c", enabled: true),
+        ])
+        #expect(args == [
+            "--cors", "--permissive",
+            "--mcp", "/a",
+            "--mcp", "/c",
+        ])
+    }
+
+    @Test func testEmptyPathIsSkipped() {
+        // Defensive: an empty path would cause apfel to crash on start.
+        let args = ApfelArgumentsBuilder.build(mcpServers: [
+            MCPServerConfig(name: "broken", path: "", enabled: true),
+            MCPServerConfig(name: "good", path: "/ok", enabled: true),
+        ])
+        #expect(args == ["--cors", "--permissive", "--mcp", "/ok"])
+    }
+}
+
+@Suite("QuickSettings MCP")
+struct QuickSettingsMCPTests {
+
+    @Test func testDefaultMcpServersIsEmpty() {
+        let s = QuickSettings()
+        #expect(s.mcpServers.isEmpty)
+    }
+
+    @Test func testMcpServersRoundTripThroughCodable() throws {
+        var s = QuickSettings()
+        s.mcpServers = [
+            MCPServerConfig(name: "calc", path: "/tmp/calc.py", enabled: true),
+            MCPServerConfig(name: "web", path: "/tmp/web.py", enabled: false),
+        ]
+        let data = try JSONEncoder().encode(s)
+        let back = try JSONDecoder().decode(QuickSettings.self, from: data)
+        #expect(back.mcpServers.count == 2)
+        #expect(back.mcpServers.first?.name == "calc")
+        #expect(back.mcpServers.last?.enabled == false)
+    }
+
+    @Test func testLegacySettingsWithoutMcpServersDecodes() throws {
+        let legacy = #"""
+        {"hotkeyKeyCode":49,"hotkeyModifiers":524288,"autoCopy":true,"launchAtLogin":true,"showMenuBar":true,"checkForUpdatesOnLaunch":true,"hasSeenWelcome":true,"launchAtLoginPromptShown":true}
+        """#
+        let s = try JSONDecoder().decode(QuickSettings.self, from: Data(legacy.utf8))
+        #expect(s.mcpServers.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #9. Users can configure local MCP servers from Settings. Each server has an on/off toggle, a friendly name, and a path. On next launch, `apfel --serve` receives `--mcp <path>` for every enabled server.

## Design

`ApfelArgumentsBuilder.build(mcpServers:)` is a pure function:

```swift
build(mcpServers: []) == ["--cors", "--permissive"]
build(mcpServers: [calc(enabled: true)])  == ["--cors", "--permissive", "--mcp", "/tmp/calc.py"]
build(mcpServers: [calc(enabled: false)]) == ["--cors", "--permissive"]
```

`ServerManager(settings:)` feeds the result into `ApfelServer(arguments:)` so the spawn is deterministic. Changes applied on next launch (documented in the editor header).

## TDD coverage

- `MCPServerConfigTests` (3): defaults, Codable round-trip, unique IDs
- `ApfelArgumentsBuilderTests` (6): every combination of enabled/disabled/empty-path, plus order preservation
- `QuickSettingsMCPTests` (3): default empty, Codable round-trip, legacy blob tolerance

## Test plan

- [x] `swift test` green (212 / 15 suites, +12 from baseline)
- [x] `swift build -c release` clean
- [x] Settings shows an MCP table with toggles + inline editing
- [x] Add button creates a new row; browse button uses NSOpenPanel
- [x] Disabled rows do NOT get `--mcp` added to the spawn
- [x] Legacy QuickSettings blobs decode cleanly (empty `mcpServers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)