### PR TITLE
feat(#12): voice-to-prompt via ohr (on-device speech recognition)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -30,5 +30,7 @@
     <true/>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2026 Arthur Ficial. MIT License.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>apfel-quick uses the microphone only when you press the voice button, so ohr can transcribe your speech into text on-device.</string>
 </dict>
 </plist>

--- a/Sources/Models/QuickSettings.swift
+++ b/Sources/Models/QuickSettings.swift
@@ -28,6 +28,10 @@ struct QuickSettings: Codable, Sendable {
     // MCP servers (attached to apfel --serve at launch)
     var mcpServers: [MCPServerConfig] = []
 
+    // Voice input (ohr)
+    var voiceEnabled: Bool = true
+    var ohrBinaryPathOverride: String?
+
     // Persistence key
     static let defaultsKey = "QuickSettings"
 
@@ -47,6 +51,8 @@ struct QuickSettings: Codable, Sendable {
         savedPrompts = try c.decodeIfPresent([SavedPrompt].self, forKey: .savedPrompts) ?? SavedPrompt.defaults
         appearance = try c.decodeIfPresent(AppearancePreference.self, forKey: .appearance) ?? .system
         mcpServers = try c.decodeIfPresent([MCPServerConfig].self, forKey: .mcpServers) ?? []
+        voiceEnabled = try c.decodeIfPresent(Bool.self, forKey: .voiceEnabled) ?? true
+        ohrBinaryPathOverride = try c.decodeIfPresent(String.self, forKey: .ohrBinaryPathOverride)
     }
 
     init() {}

--- a/Sources/Services/VoiceTranscriber.swift
+++ b/Sources/Services/VoiceTranscriber.swift
@@ -1,0 +1,93 @@
+import Foundation
+import ApfelServerKit
+
+/// Typed errors surfaced by the ohr-based voice transcriber.
+enum VoiceTranscriberError: Error, Equatable, Sendable {
+    case binaryNotFound
+    case spawnFailed(String)
+}
+
+/// Wraps an `ohr --listen` subprocess and exposes its stdout lines as
+/// an `AsyncStream<String>`. Actor-isolated for safe start/stop from
+/// the main view model and from test code alike.
+actor VoiceTranscriber {
+
+    private let binaryFinder: @Sendable () -> String?
+    private let extraArgs: [String]
+    private var process: Process?
+    private var stdoutReader: Task<Void, Never>?
+    private var continuation: AsyncStream<String>.Continuation?
+    private let stream: AsyncStream<String>
+
+    /// Whether a subprocess is currently running.
+    var isRunning: Bool { process?.isRunning ?? false }
+
+    /// Stream of stdout lines the transcriber has emitted so far, plus
+    /// lines it emits in the future until `stop()` is called or the
+    /// process exits on its own.
+    var lines: AsyncStream<String> { stream }
+
+    init(
+        binaryFinder: @Sendable @escaping () -> String? = { ApfelBinaryFinder.find(name: "ohr") },
+        extraArgs: [String] = ["--listen", "--quiet"]
+    ) {
+        self.binaryFinder = binaryFinder
+        self.extraArgs = extraArgs
+        var cont: AsyncStream<String>.Continuation!
+        self.stream = AsyncStream { cont = $0 }
+        self.continuation = cont
+    }
+
+    /// Spawn `ohr` with the configured arguments. Throws on missing binary
+    /// or spawn failure.
+    func start() async throws {
+        guard let binary = binaryFinder() else {
+            throw VoiceTranscriberError.binaryNotFound
+        }
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = extraArgs
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            throw VoiceTranscriberError.spawnFailed(error.localizedDescription)
+        }
+        self.process = process
+
+        let continuation = self.continuation
+        stdoutReader = Task.detached(priority: .userInitiated) {
+            let handle = pipe.fileHandleForReading
+            var buffer = Data()
+            while true {
+                let chunk = handle.availableData
+                if chunk.isEmpty { break }
+                buffer.append(chunk)
+                while let newline = buffer.firstIndex(of: 0x0A) {
+                    let lineBytes = buffer.subdata(in: 0..<newline)
+                    let line = String(data: lineBytes, encoding: .utf8) ?? ""
+                    buffer.removeSubrange(0...newline)
+                    if !line.isEmpty { continuation?.yield(line) }
+                }
+            }
+            // Flush any trailing partial line.
+            if !buffer.isEmpty, let tail = String(data: buffer, encoding: .utf8), !tail.isEmpty {
+                continuation?.yield(tail)
+            }
+        }
+    }
+
+    /// Terminate the subprocess. Safe to call multiple times; no-op when
+    /// nothing is running.
+    func stop() {
+        if let process, process.isRunning {
+            process.terminate()
+        }
+        process = nil
+        stdoutReader?.cancel()
+        stdoutReader = nil
+    }
+}

--- a/Sources/ViewModels/QuickViewModel.swift
+++ b/Sources/ViewModels/QuickViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AppKit
 import Observation
+import ApfelServerKit
 
 @Observable @MainActor final class QuickViewModel {
 
@@ -9,11 +10,15 @@ import Observation
     var input: String = ""
     var output: String = ""
     var isStreaming: Bool = false
+    var isRecording: Bool = false
     var errorMessage: String? = nil
     var settings: QuickSettings
     var updateState: UpdateState = .idle
     /// True briefly after auto-copy fires, so the UI can flash a "Copied!" indicator.
     var justCopied: Bool = false
+
+    @ObservationIgnored private var voiceTask: Task<Void, Never>?
+    @ObservationIgnored private var voiceTranscriber: VoiceTranscriber?
 
     // MARK: - Dependencies
 
@@ -142,6 +147,61 @@ import Observation
             try? await Task.sleep(for: pollInterval)
         }
         return service
+    }
+
+    // MARK: - Voice (ohr)
+
+    /// Start or stop ohr-backed voice transcription. Toggles `isRecording`.
+    func toggleVoice() async {
+        if isRecording {
+            await stopVoice()
+        } else {
+            await startVoice()
+        }
+    }
+
+    private func startVoice() async {
+        guard !isRecording else { return }
+        let pathOverride = settings.ohrBinaryPathOverride
+        let transcriber = VoiceTranscriber(
+            binaryFinder: {
+                if let pathOverride, !pathOverride.isEmpty { return pathOverride }
+                return ApfelBinaryFinder.find(name: "ohr")
+            }
+        )
+        do {
+            try await transcriber.start()
+        } catch VoiceTranscriberError.binaryNotFound {
+            errorMessage = "ohr not found. Install: brew install Arthur-Ficial/tap/ohr"
+            return
+        } catch {
+            errorMessage = "Voice start failed: \(error.localizedDescription)"
+            return
+        }
+        voiceTranscriber = transcriber
+        isRecording = true
+        errorMessage = nil
+        voiceTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await line in await transcriber.lines {
+                if Task.isCancelled { break }
+                // Append transcribed text to whatever is already in the input.
+                if self.input.isEmpty {
+                    self.input = line
+                } else {
+                    self.input = self.input + " " + line
+                }
+            }
+            self.isRecording = false
+        }
+    }
+
+    private func stopVoice() async {
+        await voiceTranscriber?.stop()
+        voiceTranscriber = nil
+        voiceTask?.cancel()
+        voiceTask = nil
+        isRecording = false
     }
 
     // MARK: - Cancel

--- a/Sources/Views/OverlayView.swift
+++ b/Sources/Views/OverlayView.swift
@@ -33,6 +33,24 @@ struct OverlayView: View {
                     .onSubmit { Task { await viewModel.submit() } }
                     .disabled(viewModel.isStreaming)
 
+                // Voice (ohr) mic button — hidden when the user disables voice in settings
+                if viewModel.settings.voiceEnabled {
+                    Button {
+                        Task { await viewModel.toggleVoice() }
+                    } label: {
+                        Image(systemName: viewModel.isRecording ? "mic.fill" : "mic")
+                            .foregroundStyle(
+                                viewModel.isRecording
+                                    ? Color(red: 0.90, green: 0.25, blue: 0.25)
+                                    : Color.secondary
+                            )
+                            .font(.system(size: 16))
+                            .symbolEffect(.pulse, isActive: viewModel.isRecording)
+                    }
+                    .buttonStyle(.plain)
+                    .help(viewModel.isRecording ? "Stop listening" : "Voice (ohr)")
+                }
+
                 // Send / stop / copied indicator — same slot, different icon
                 Button {
                     Task { await viewModel.submit() }

--- a/Sources/Views/SettingsView.swift
+++ b/Sources/Views/SettingsView.swift
@@ -71,6 +71,34 @@ struct SettingsView: View {
 
             Divider()
 
+            // Voice (ohr) - only the toggle lives at the top level; power users
+            // can pin a custom binary path here too.
+            Toggle("Enable voice input (requires ohr)", isOn: $viewModel.settings.voiceEnabled)
+                .onChange(of: viewModel.settings.voiceEnabled) { _, _ in viewModel.settings.save() }
+
+            if viewModel.settings.voiceEnabled {
+                HStack(spacing: 8) {
+                    Text("ohr path:")
+                        .foregroundStyle(.secondary)
+                        .font(.system(size: 11))
+                    TextField(
+                        "auto-detect",
+                        text: Binding(
+                            get: { viewModel.settings.ohrBinaryPathOverride ?? "" },
+                            set: { newValue in
+                                viewModel.settings.ohrBinaryPathOverride =
+                                    newValue.isEmpty ? nil : newValue
+                                viewModel.settings.save()
+                            }
+                        )
+                    )
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11))
+                }
+            }
+
+            Divider()
+
             MCPServersEditor(viewModel: viewModel)
 
             // Show welcome screen on next launch

--- a/Tests/VoiceTranscriberTests.swift
+++ b/Tests/VoiceTranscriberTests.swift
@@ -1,0 +1,124 @@
+import Testing
+import Foundation
+@testable import apfel_quick
+
+/// TDD (RED) for ohr-based voice transcription (issue #12).
+///
+/// Spec:
+/// - `VoiceTranscriber` is an actor managing an `ohr --listen` subprocess.
+/// - `start()` throws if the ohr binary cannot be found.
+/// - While running, stdout lines are pushed into an AsyncStream<String>.
+/// - `stop()` terminates the process; double-stop is a no-op.
+/// - `QuickSettings.voiceEnabled` (default true) gates the feature in the UI.
+
+@Suite("VoiceTranscriber")
+struct VoiceTranscriberTests {
+
+    @Test func testStartThrowsWhenBinaryNotFound() async {
+        let transcriber = VoiceTranscriber(binaryFinder: { nil })
+        do {
+            try await transcriber.start()
+            Issue.record("expected throw")
+        } catch let error as VoiceTranscriberError {
+            #expect(error == .binaryNotFound)
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+    }
+
+    @Test func testStopWhenNotStartedIsNoOp() async {
+        let transcriber = VoiceTranscriber(binaryFinder: { "/nonexistent" })
+        await transcriber.stop()
+        let running = await transcriber.isRunning
+        #expect(running == false)
+    }
+
+    @Test func testStartThrowsWhenSpawnFails() async {
+        // /etc/hosts exists but is not executable. Process.run() fails.
+        let transcriber = VoiceTranscriber(binaryFinder: { "/etc/hosts" })
+        do {
+            try await transcriber.start()
+            Issue.record("expected throw")
+        } catch let error as VoiceTranscriberError {
+            guard case .spawnFailed = error else {
+                Issue.record("wrong error: \(error)")
+                return
+            }
+        } catch {
+            Issue.record("wrong error type: \(error)")
+        }
+    }
+
+    @Test func testLinesStreamYieldsStdoutLines() async throws {
+        // /bin/echo writes one line and exits. It's a reasonable stand-in
+        // for a subprocess whose stdout we want to consume.
+        let transcriber = VoiceTranscriber(
+            binaryFinder: { "/bin/echo" },
+            extraArgs: ["hello world"]
+        )
+        try await transcriber.start()
+        var collected: [String] = []
+        for await line in await transcriber.lines {
+            collected.append(line)
+            if collected.count >= 1 { break }
+        }
+        await transcriber.stop()
+        #expect(collected.first == "hello world")
+    }
+
+    @Test func testIsRunningReflectsLifecycle() async throws {
+        let transcriber = VoiceTranscriber(
+            binaryFinder: { "/bin/sleep" },
+            extraArgs: ["5"]
+        )
+        try await transcriber.start()
+        #expect(await transcriber.isRunning == true)
+        await transcriber.stop()
+        // Give the kernel a moment to reap the process.
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(await transcriber.isRunning == false)
+    }
+
+    @Test func testDoubleStopIsSafe() async throws {
+        let transcriber = VoiceTranscriber(
+            binaryFinder: { "/bin/sleep" },
+            extraArgs: ["5"]
+        )
+        try await transcriber.start()
+        await transcriber.stop()
+        await transcriber.stop()
+    }
+}
+
+@Suite("QuickSettings voice")
+struct QuickSettingsVoiceTests {
+
+    @Test func testDefaultVoiceEnabled() {
+        let s = QuickSettings()
+        #expect(s.voiceEnabled == true)
+    }
+
+    @Test func testDefaultOhrPathIsNil() {
+        let s = QuickSettings()
+        #expect(s.ohrBinaryPathOverride == nil)
+    }
+
+    @Test func testVoiceFieldsRoundTrip() throws {
+        var s = QuickSettings()
+        s.voiceEnabled = false
+        s.ohrBinaryPathOverride = "/opt/homebrew/bin/ohr"
+        let data = try JSONEncoder().encode(s)
+        let back = try JSONDecoder().decode(QuickSettings.self, from: data)
+        #expect(back.voiceEnabled == false)
+        #expect(back.ohrBinaryPathOverride == "/opt/homebrew/bin/ohr")
+    }
+
+    @Test func testLegacyBlobDecodes() throws {
+        let legacy = #"""
+        {"hotkeyKeyCode":49,"hotkeyModifiers":524288,"autoCopy":true,"launchAtLogin":true,"showMenuBar":true,"checkForUpdatesOnLaunch":true,"hasSeenWelcome":true,"launchAtLoginPromptShown":true}
+        """#
+        let s = try JSONDecoder().decode(QuickSettings.self, from: Data(legacy.utf8))
+        #expect(s.voiceEnabled == true)
+        #expect(s.ohrBinaryPathOverride == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #12. Adds a microphone button next to the send button. Press to start transcribing via `ohr --listen`, press again to stop. Transcribed text appends to whatever is in the input field so typing + dictation mix naturally. 100% on-device.

## Design

- `VoiceTranscriber` actor wraps an `ohr --listen --quiet` subprocess and streams stdout lines as `AsyncStream<String>`. Dependency-injectable binary finder makes the whole thing testable without any real ohr or microphone.
- `VoiceTranscriberError` surfaces the two realistic failure modes: `.binaryNotFound` (install hint shown to user) and `.spawnFailed`.
- `QuickSettings.voiceEnabled` (default true) gates the UI. `QuickSettings.ohrBinaryPathOverride` lets power users pin a specific ohr binary.
- `QuickViewModel.toggleVoice()` drives lifecycle; transcription lines append to `input` so users can dictate, edit, then send.
- Discovery piggybacks on `ApfelBinaryFinder.find(name: "ohr")` from apfel-server-kit - the same search order apfel itself uses.
- `Info.plist` gets `NSMicrophoneUsageDescription` so macOS can prompt appropriately on first use.

## TDD coverage

- `VoiceTranscriberTests` (6): binaryNotFound, idempotent stop, spawnFailed via non-executable, stdout streaming via `/bin/echo`, isRunning lifecycle via `/bin/sleep`, double-stop safety
- `QuickSettingsVoiceTests` (4): default `true`, default nil override, full round-trip, legacy blob tolerance

## Test plan

- [x] `swift test` green (210 / 15 suites, +10 from baseline)
- [x] `swift build -c release` clean
- [x] Mic button appears in the overlay when `voiceEnabled`
- [x] Tapping mic while `ohr` is missing surfaces a helpful install hint
- [x] Legacy QuickSettings blobs decode with voice enabled + no override

🤖 Generated with [Claude Code](https://claude.com/claude-code)