### PR TITLE
fix: preserve dark-mode text color in markdown output (#20)

### DIFF
--- a/Sources/Services/MarkdownRenderer.swift
+++ b/Sources/Services/MarkdownRenderer.swift
@@ -53,6 +53,7 @@ private struct AttributedStringWalker: MarkupWalker {
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .backgroundColor: NSColor.secondarySystemFill,
+            .foregroundColor: NSColor.labelColor,
         ]
         output.append(NSAttributedString(string: code, attributes: attrs))
     }
@@ -190,7 +191,12 @@ private struct AttributedStringWalker: MarkupWalker {
     // MARK: - Helpers
 
     private func appendText(_ text: String) {
-        var attrs: [NSAttributedString.Key: Any] = [:]
+        // Default to the adaptive system label color so output stays visible
+        // in both light and dark mode (issue #20). Blockquote / link branches
+        // below override this when they need a different color.
+        var attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.labelColor,
+        ]
 
         // Determine effective bold state (explicit bold OR table header)
         let effectiveBold = fontTraits.contains(.bold) || isTableHeader

--- a/Tests/MarkdownRendererTests.swift
+++ b/Tests/MarkdownRendererTests.swift
@@ -13,6 +13,61 @@ struct MarkdownRendererTests {
         #expect(result.string == "Hello world")
     }
 
+    // MARK: - Dark-mode color correctness (issue #20)
+    // Plain text rendered inside NSTextView defaults to raw black when no
+    // `.foregroundColor` is set, which is invisible / near-invisible in dark
+    // mode. The renderer must set `NSColor.labelColor` so the text adapts
+    // to the current system appearance.
+
+    @Test func testPlainTextUsesAdaptiveLabelColor() {
+        let result = MarkdownRenderer.render("Hello world")
+        let range = (result.string as NSString).range(of: "Hello world")
+        let attrs = result.attributes(at: range.location, effectiveRange: nil)
+        let color = attrs[.foregroundColor] as? NSColor
+        #expect(color == NSColor.labelColor,
+                "Plain text must use NSColor.labelColor so it stays visible in dark mode (issue #20)")
+    }
+
+    @Test func testBoldTextUsesAdaptiveLabelColor() {
+        let result = MarkdownRenderer.render("This is **bold** text")
+        let range = (result.string as NSString).range(of: "bold")
+        let attrs = result.attributes(at: range.location, effectiveRange: nil)
+        let color = attrs[.foregroundColor] as? NSColor
+        #expect(color == NSColor.labelColor,
+                "Bold text must use NSColor.labelColor so it stays visible in dark mode (issue #20)")
+    }
+
+    @Test func testHeadingUsesAdaptiveLabelColor() {
+        let result = MarkdownRenderer.render("# A heading")
+        let range = (result.string as NSString).range(of: "A heading")
+        let attrs = result.attributes(at: range.location, effectiveRange: nil)
+        let color = attrs[.foregroundColor] as? NSColor
+        #expect(color == NSColor.labelColor,
+                "Heading text must use NSColor.labelColor so it stays visible in dark mode (issue #20)")
+    }
+
+    @Test func testCodeBlockUsesAdaptiveLabelColor() {
+        let result = MarkdownRenderer.render("""
+        ```
+        let x = 1
+        ```
+        """)
+        let range = (result.string as NSString).range(of: "let x = 1")
+        let attrs = result.attributes(at: range.location, effectiveRange: nil)
+        let color = attrs[.foregroundColor] as? NSColor
+        #expect(color == NSColor.labelColor,
+                "Fenced code block text must use NSColor.labelColor so it stays visible in dark mode (issue #20)")
+    }
+
+    @Test func testInlineCodeUsesAdaptiveLabelColor() {
+        let result = MarkdownRenderer.render("Use `let` for constants")
+        let range = (result.string as NSString).range(of: "let")
+        let attrs = result.attributes(at: range.location, effectiveRange: nil)
+        let color = attrs[.foregroundColor] as? NSColor
+        #expect(color == NSColor.labelColor,
+                "Inline code must use NSColor.labelColor so it stays visible in dark mode (issue #20)")
+    }
+
     // MARK: - Bold
 
     @Test func testBoldRendered() {


### PR DESCRIPTION
## Summary

Fixes #20 — dark-mode markdown output text is invisible (rendered in raw black against the dark background).

## Root cause

`MarkdownRenderer` builds attributed strings whose `attrs` dict only sets `.foregroundColor` for two branches: link text (`linkColor`) and blockquote text (`secondaryLabelColor`). Plain text, bold, headings, and code blocks fall through with **no foreground color attribute at all**. NSTextView then defaults unattributed text to raw black, which is fine in light mode and broken in dark mode.

The TextField (input) uses SwiftUI's `.plain` style and adapts automatically, which is why the user reported "input looks right, output is black" — SwiftUI handles its own text color; AppKit's `NSTextView` does not.

## Fix

Default every `attrs` dict in `MarkdownRenderer` to `.foregroundColor: NSColor.labelColor`. `labelColor` is the system's **semantic adaptive** color — black in light mode, white/light-gray in dark mode, automatically. Existing overrides (`.linkColor` for links, `.secondaryLabelColor` for blockquotes) still win because they apply *after* the default.

Two call sites:
1. `visitCodeBlock` — adds `.foregroundColor: NSColor.labelColor` alongside the existing `.font` and `.backgroundColor`.
2. `appendText` — defaults `attrs` to `[.foregroundColor: NSColor.labelColor]` instead of `[:]`. Link and blockquote branches override as before.

## Tests (TDD, red → green)

Five new tests in `Tests/MarkdownRendererTests.swift` following the existing `testBlockQuoteHasForegroundColor` pattern:

- `testPlainTextUsesAdaptiveLabelColor`
- `testBoldTextUsesAdaptiveLabelColor`
- `testHeadingUsesAdaptiveLabelColor`
- `testCodeBlockUsesAdaptiveLabelColor`
- `testInlineCodeUsesAdaptiveLabelColor`

Each asserts `attrs[.foregroundColor] == NSColor.labelColor` at a known text range. All five started red (`color → nil`), turned green after the fix.

## Results

- `swift test`: **263 / 263 passing** (+5 new).

## Test plan

- [x] Red phase: the five new tests fail with `color → nil` against `NSColor.labelColor` before the fix.
- [x] Green phase: all 263 tests pass after the fix, including the five new ones.
- [x] Link branch still uses `linkColor` — check `testExistingLinkColorUnaffected` (pre-existing `testBlockQuoteHasForegroundColor` covers the adjacent override path).
- [ ] Manual visual check by the reporter (@he0xA1) on a fresh build in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
